### PR TITLE
Tweet oembed #35

### DIFF
--- a/api/twitter/tweet.py
+++ b/api/twitter/tweet.py
@@ -1,0 +1,27 @@
+import json
+import urllib.parse
+import urllib.request
+
+base_url = "https://publish.twitter.com/oembed"
+
+default_params = {
+    "url": "https://twitter.com/trace_map/status/",
+    "hide_media": True,
+    "hide_thread": True,
+    "omit_script": True,
+    "related": "trace_map",
+    "link_color": "#9729ff",
+    "dnt": True,
+}
+
+
+def get_html( tweetId):
+    params = default_params.copy()
+    params['url'] = params['url'] + tweetId
+    params_string = urllib.parse.urlencode(params)
+    url = base_url + "?" + params_string
+    with urllib.request.urlopen(url) as response:
+        data = response.read().decode('utf-8')
+        data_json = json.loads( data)
+        html = data_json['html']
+        return html;

--- a/api/twitter/tweet.py
+++ b/api/twitter/tweet.py
@@ -14,10 +14,9 @@ default_params = {
     "dnt": True,
 }
 
-
-def get_html( tweetId):
+def get_html( tweet_id):
     params = default_params.copy()
-    params['url'] = params['url'] + tweetId
+    params['url'] = params['url'] + tweet_id
     params_string = urllib.parse.urlencode(params)
     url = base_url + "?" + params_string
     with urllib.request.urlopen(url) as response:
@@ -25,3 +24,20 @@ def get_html( tweetId):
         data_json = json.loads( data)
         html = data_json['html']
         return html;
+
+def get_timeline_html( user_id):
+    # Returns a users timeline
+    # Not usable right now because we need single tweet objects
+    # Lets keep it for later
+    params = {
+        "url":"https://twitter.com/TwitterDev/timelines/" + user_id,
+        "limit":20,
+        "omit_script":1,
+        "dnt": True
+    }
+    params_string = urllib.parse.urlencode(params)
+    url = base_url + "?" + params_string
+    with urllib.request.urlopen(url) as response:
+        data = response.read().decode('utf-8')
+        data_json = json.loads( data)
+        return data_json

--- a/api/twitter/twitterApi.py
+++ b/api/twitter/twitterApi.py
@@ -160,22 +160,23 @@ def get_user_timeline( user_id):
     tmp_tweets = __request_user_timeline( user_id)
     response = {}
     response['by_time'] = []
+    if 'errors' in tmp_tweets:
+        return tmp_tweets
     for tweet in tmp_tweets:
         tmp_response = {}
         tmp_response['id_str'] = tweet['id_str']
         tmp_response['retweet_count'] = tweet['retweet_count']
-        tmp_response['retweeted'] = True
         tmp_response['created_at'] = tweet['created_at']
-        if 'retweeted_status' not in tweet:
-            tmp_response['retweeted'] = False
+        if 'retweeted_status' in tweet:
+            tmp_response['retweeted'] = tweet['retweeted_status']['id_str'];
         response['by_time'].append(tmp_response)
 
     response['by_retweets'] = sorted(response['by_time'], key=lambda tweet: tweet['retweet_count'], reverse=True)
     response['by_time_no_rts'] = list(filter(
-        lambda x: not x['retweeted'], 
+        lambda x: 'retweeted' not in x, 
         response['by_time']))
     response['by_retweets_no_rts'] = list(filter(
-        lambda x: not x['retweeted'], 
+        lambda x: 'retweeted' not in x, 
         response['by_retweets']))
     return response
 

--- a/api/twitter/twitterApi.py
+++ b/api/twitter/twitterApi.py
@@ -136,3 +136,4 @@ def get_tweet_data( tweet_id):
     results = {}
     results['response'] = __format_tweet_data(data)
     return results
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ neo4j-driver
 pytest
 TwitterAPI
 uwsgi
+

--- a/server.py
+++ b/server.py
@@ -22,6 +22,10 @@ def twitter_get_tweet_info(tweet_id):
 def twitter_get_tweet_data(tweet_id):
     return jsonify(twitterApi.get_tweet_data(tweet_id))
 
+@app.route('/twitter/get_user_timeline/<string:user_id>')
+def twitter_get_user_timeline(user_id):
+    return jsonify(twitterApi.get_user_timeline(user_id));
+
 """Takes a comma seperated list of user_ids
     returns a user_info json object
 """

--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify
 from flask_cors import CORS
 
 import api.twitter.twitterApi as twitterApi
+import api.twitter.tweet as tweet
 import api.neo4j.neo4jApi as neo4jApi
 
 app = Flask(__name__)
@@ -27,6 +28,10 @@ def twitter_get_tweet_data(tweet_id):
 @app.route('/twitter/get_user_info/<string:user_ids>')
 def twitter_get_user_info(user_ids):
     return jsonify(twitterApi.get_user_info(user_ids.split(",")))
+
+@app.route('/tweet/get_html/<string:tweet_id>')
+def tweet_get_html(tweet_id):
+    return jsonify(tweet.get_html(tweet_id))
 
 """Takes a comma seperated list of user_ids and returns the subnetwork of followship
    relations between those users


### PR DESCRIPTION
### New Route for receiving the last 200 tweets of a user
 **Why so many?**
According to the sort type of user timelines in our tool, its important to get as many tweets as possible.
If not, sorting by number of retweets is not effective.
In the front end, the component managing a users timeline is requesting all the tweets but rendering just a few until the user scrolls down, like you know it from twitter & facebook when scrolling down your timeline.

**Why not even more?**
The request already takes around 4 seconds with 200tweets.
If we experience, that not enough tweets are shown, we can still change it to request more tweets and compute more stuff on the frontend to increase request speed.