### PR TITLE
Integrate apm #88

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ crawler/temp/*
 user-data/newsletter_subscribers.txt
 user-data/beta_users.txt
 .vscode
+docker-compose.yml

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+COREPATH=/usr/local/bin/tracemap
+rsync -av --exclude-from=.gitignore --exclude .git --exclude deploy.sh ./ tm-deploy-staging:$COREPATH/${PWD##*/}
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,6 @@ services:
     container_name: tracemap-api
     build: .
     ports:
-     - '5100:5100'
      - '5000:5000'
     volumes:
      - .:/usr/src/app

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,4 +8,4 @@ services:
     volumes:
      - .:/usr/src/app
     env_file: .env
-    
+    network_mode: "host"    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,1 +1,0 @@
-docker-compose.dev.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,1 @@
-version: '3'
-services:
-  web:
-    container_name: tracemap-api
-    build: .
-    ports:
-     - '5000:5000'
-    volumes:
-     - .:/usr/src/app
-    env_file: .env
+docker-compose.dev.yml

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,6 @@
 asn1crypto==0.24.0
 attrs==18.1.0
+blinker==1.4
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
@@ -19,6 +20,7 @@ oauthlib==2.0.7
 pluggy==0.6.0
 py==1.5.3
 pycrypto==2.6.1
+pygobject==3.26.1
 pytest==3.5.1
 pyxdg==0.25
 requests==2.18.4

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -4,6 +4,7 @@ certifi==2018.4.16
 chardet==3.0.4
 click==6.7
 cryptography==2.1.4
+elastic-apm==3.0.2
 Flask==1.0.2
 Flask-Cors==3.0.4
 idna==2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ TwitterAPI
 uwsgi
 sty
 werkzeug
+elastic-apm[flask]

--- a/server.py
+++ b/server.py
@@ -1,6 +1,8 @@
 from flask import Flask, jsonify, request, Response
 from flask_cors import CORS
 
+from elasticapm.contrib.flask import ElasticAPM
+
 import api.twitter.twitterApi as twitterApi
 import api.twitter.tweet as tweet
 import api.neo4j.neo4jApi as neo4jApi
@@ -8,6 +10,7 @@ import api.newsletter.newsletterApi as newsletterApi
 import api.auth.betaAuth as betaAuth
 
 app = Flask(__name__)
+apm = ElasticAPM(app)
 cors = CORS(app, resources={r"/*": {"origins": "*"}})
 
 """Request health status of the api"""

--- a/server.py
+++ b/server.py
@@ -10,7 +10,7 @@ import api.newsletter.newsletterApi as newsletterApi
 import api.auth.betaAuth as betaAuth
 
 app = Flask(__name__)
-apm = ElasticAPM(app)
+apm = ElasticAPM(app, logging=True)
 cors = CORS(app, resources={r"/*": {"origins": "*"}})
 
 """Request health status of the api"""


### PR DESCRIPTION
Resolves #88  
Epic: #58 

# Important changes

- apm client has been added to our backend dependencies
- backend docker now sees the whole localhost network from host to be able to connect to apm server
- apm now monitors flask application logs

# Review hints

- [x] fiddle around in the tool and check the [Dashboard](http://0.0.0.0:5601/app/apm#/tracemap-backend-api/transactions?_g=(refreshInterval:(pause:!f,value:5000),time:(from:now-24h,mode:quick,to:now))) for monitoring entries (already deployed, no `git checkout` or `git pull` needed.