### PR TITLE
add log file date conversion script

### DIFF
--- a/bin/convert-dates.js
+++ b/bin/convert-dates.js
@@ -1,0 +1,17 @@
+// This script takes legacy tracemap gen logs and transforms the millisecond-based timestamp
+// into a iso date string, saving it under the new key `datetime`.
+// The old key `time_str` is deleted in the process.
+
+const fs = require('fs')
+const eol = require('os').EOL
+const file = '/path/to/logfile/with/old/timestamp/format.jsonl'
+const data = fs.readFileSync(file, {encoding: 'utf8'}).trim().split(eol)
+
+data.forEach(line => {
+	let log = JSON.parse(line)
+	datetime = new Date(parseInt(log['time_str']) * 1000)
+	delete log['time_str']
+	log['datetime'] = datetime.toISOString()
+	console.log(JSON.stringify(log))
+});
+


### PR DESCRIPTION
Resolves #110 
Epic: #58 

Merge together with tracemap/tracemap-tool#144

# Important changes

- converted datetimes from timestamps to iso date format in tracemaps-generated.jsonl
- add the script that I used to do that
